### PR TITLE
AEM 6.5.2: Use uber-jar 6.5.2.0 instead of 6.5.2

### DIFF
--- a/6.5.2/pom.xml
+++ b/6.5.2/pom.xml
@@ -90,13 +90,13 @@
       <dependency>
         <groupId>com.adobe.aem</groupId>
         <artifactId>uber-jar</artifactId>
-        <version>6.5.2</version>
+        <version>6.5.2.0</version>
         <classifier>apis</classifier>
       </dependency>
       <dependency>
         <groupId>com.adobe.aem</groupId>
         <artifactId>uber-jar</artifactId>
-        <version>6.5.2</version>
+        <version>6.5.2.0</version>
         <classifier>apis-with-deprecations</classifier>
       </dependency>
 


### PR DESCRIPTION
Fixes #20